### PR TITLE
SubjectAltName (SAN) needs setting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     branches: [ master ]
 
+  workflow_dispatch:
   schedule:
      - cron: '0 0 * * FRI'
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: CI pipeline
 
 on:
   push:
@@ -13,6 +13,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+
+  schedule:
+     - cron: '0 0 * * FRI'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker_test_runner
 
-![python-app workflow](https://github.com/ployt0/docker_test_runner/actions/workflows/python-app.yml/badge.svg)
+![CI workflow](https://github.com/ployt0/docker_test_runner/actions/workflows/CI.yml/badge.svg)
 
 A minimal docker container amenable to being tested, as a web and SSH server, by a github workflow.
 

--- a/pb_provisioner/provision_server.yml
+++ b/pb_provisioner/provision_server.yml
@@ -51,7 +51,7 @@
           creates: "{{ tls_cert_key }}"
           cmd: >
             openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:prime256v1
-            -days 365 -nodes -x509 -subj "/CN={{ domain_name }}"
+            -days 365 -nodes -x509 -subj "/CN={{ domain_name }}" -addext "subjectAltName = DNS:{{ domain_name }}"
             -keyout "{{ tls_cert_key }}" -out "{{ tls_cert_file }}"
 
 

--- a/pb_provisioner/provision_server.yml
+++ b/pb_provisioner/provision_server.yml
@@ -51,7 +51,8 @@
           creates: "{{ tls_cert_key }}"
           cmd: >
             openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:prime256v1
-            -days 365 -nodes -x509 -subj "/CN={{ domain_name }}" -addext "subjectAltName = DNS:{{ domain_name }}"
+            -days 365 -nodes -x509 -subj "/CN={{ domain_name }}"
+            -addext "subjectAltName = DNS:{{ domain_name }},IP:{{ domain_name }}"
             -keyout "{{ tls_cert_key }}" -out "{{ tls_cert_file }}"
 
 


### PR DESCRIPTION
Unsure if DNS and IP can be used to prefix the same identifier. Domain_name was a misnomer, ansible_host, which determines it, is an IP. This only matters to python requests and browsers, the primitive curl used here isn't bothered, hopefully hedging DNS and IP here don't affect curl.